### PR TITLE
Use RLMArray directly instead of copying into Swift array

### DIFF
--- a/WeatherApp/Helpers/DatabaseHelper.swift
+++ b/WeatherApp/Helpers/DatabaseHelper.swift
@@ -14,22 +14,15 @@ class DatabaseHelper {
     func storeCities(cities: [City]) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
             let realm = RLMRealm.defaultRealm()
-            let allCities = City.allObjectsInRealm(realm)
+            let allCities = City.allObjects()
             realm.beginWriteTransaction()
             if allCities.count > 0 {
                 realm.deleteObjects(allCities)
             }
             for city in cities {
-                City.createInRealm(realm, withObject: ["name": city.name, "temperature": city.temperature, "pressure": city.pressure, "humidity": city.humidity])
+                City.createInDefaultRealmWithObject(["name": city.name, "temperature": city.temperature, "pressure": city.pressure, "humidity": city.humidity])
             }
             realm.commitWriteTransaction()
         }
     }
-    
-    func getStoredCities(callback: (RLMArray)->()) {
-        let realm = RLMRealm.defaultRealm()
-        let allCities = City.allObjectsInRealm(realm)
-        callback(allCities)
-    }
-    
 }


### PR DESCRIPTION
As discussed on [Twitter](https://twitter.com/simjp/status/501423390897364993), it's more performant (and less code) to use Realm's `RLMArray` directly rather than copy those values into a Swift Array.

The one advantage you lose is that RLMArray isn't generic, so you have to cast objects you take out of it to `City`. We're working on improving our Swift interface, which will include generic support for RLMArray.
